### PR TITLE
[codex] chore: bump version to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hosonokotaro/aoneko-shobou-ui",
-  "version": "0.5.15",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hosonokotaro/aoneko-shobou-ui",
-      "version": "0.5.15",
+      "version": "0.6.0",
       "devDependencies": {
         "@babel/preset-env": "^7.23.9",
         "@babel/preset-react": "^7.23.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hosonokotaro/aoneko-shobou-ui",
-  "version": "0.5.15",
+  "version": "0.6.0",
   "description": "",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## What changed
- bump package version from `0.5.15` to `0.6.0`
- update `package-lock.json` to match

## Why
- `master` is 3 commits ahead of the latest published tag `v0.5.15`
- the diff since `v0.5.15` includes public surface and dependency changes, so `minor` is the safer SemVer bump

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run build`