### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hosonokotaro/aoneko-shobou-ui",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hosonokotaro/aoneko-shobou-ui",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "devDependencies": {
         "@babel/preset-env": "^7.23.9",
         "@babel/preset-react": "^7.23.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hosonokotaro/aoneko-shobou-ui",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
# 概要

0.6.0 → 0.7.0 の minor バンプ。以下を含むリリース:

- #379 / #380: 依存関係のセキュリティ修正(npm audit 33件 → 0件)とテスト基盤の導入(#378)
- #382: React 19 対応 — peerDependencies を `react: ^18.2.0 || ^19.0.0` に更新、Storybook 10 化(#381)

マージ後は `npm run tag` → `npm publish` でリリースする(workflow.md のリリースフロー)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)