### PR TITLE
chore: Dependabot の GitHub Packages PAT 手動設定を削除

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,4 @@
 version: 2
-registries:
-  github-packages:
-    type: 'npm-registry'
-    url: 'https://npm.pkg.github.com'
-    token: '${{ secrets.GH_PAT }}'
 
 updates:
   - package-ecosystem: 'npm'
@@ -16,8 +11,6 @@ updates:
     target-branch: 'master'
     versioning-strategy: 'lockfile-only'
     rebase-strategy: 'auto'
-    registries:
-      - github-packages
     groups:
       storybook-ecosystem:
         patterns:


### PR DESCRIPTION
## Summary
- `.github/dependabot.yml` からトップレベルの `registries: github-packages` ブロックを削除
- npm updates 内の `registries: - github-packages` 参照を削除
- Package settings で付与済みの組み込み Read アクセスを使う構成に変更(GH_PAT シークレット依存を解消)

## Test plan
- [x] YAML の妥当性を `python3 -c "yaml.safe_load(...)"` で確認
- [x] `git diff` で必要最小限の変更のみであることを確認