### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hosonokotaro/aoneko-shobou-ui",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hosonokotaro/aoneko-shobou-ui",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "devDependencies": {
         "@babel/preset-env": "^7.23.9",
         "@babel/preset-react": "^7.23.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hosonokotaro/aoneko-shobou-ui",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## 変更概要

`@hosonokotaro/aoneko-shobou-ui` のバージョンを `0.7.0` から `0.7.1` に更新します。

## 更新理由

`v0.7.0` 以降では Dependabot 設定と開発依存を更新しました。公開 API の追加や破壊的変更はないため、patch バージョンを選択しました。

## 変更内容

- Dependabot PR #387〜#391 を `master` へマージ
- `package.json` と `package-lock.json` のバージョンを `0.7.1` に更新

## 検証

クリーンインストール後、以下はすべて成功しました。

- `npm ci`
- `npm run typecheck`
- `npm run lint`
- `npm test`（5 files / 13 tests）
- `npm run build`
- `npm audit --omit=dev`（脆弱性なし）

## 影響範囲

公開 API の変更、移行手順、設定変更はありません。

`npm audit` では ESLint 系の開発依存に由来する high 1 件が報告されますが、`npm audit --omit=dev` では脆弱性はありません。