### PR TITLE
chore: bump version to 0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hosonokotaro/aoneko-shobou-ui",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hosonokotaro/aoneko-shobou-ui",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "devDependencies": {
         "@babel/preset-env": "^7.23.9",
         "@babel/preset-react": "^7.23.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hosonokotaro/aoneko-shobou-ui",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## 変更内容
- パッケージバージョンを `0.7.1` から `0.7.2` へ更新

## バージョン種別
- patch: `v0.7.1` 以降は依存関係の更新のみで、公開 API の変更はありません。

## 検証
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`